### PR TITLE
fix bugs in download_ndk.sh

### DIFF
--- a/download_ndk.sh
+++ b/download_ndk.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 ARCH=$(uname -m)
 echo $ARCH
-if [$ARCH -ne "x86_64"]; then
+if [ $ARCH != "x86_64" ]; then
   $ARCH = "x86"
 fi
 wget http://dl.google.com/android/ndk/android-ndk-r10d-linux-$ARCH.bin


### PR DESCRIPTION
In shell scripts, the brackets are functions, and therefore need to be space-separated. Also, the `-ne` operator is for numbers, the `!=` operator is for strings.
